### PR TITLE
Add shipping: Shippo integration, label management, order status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,110 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+# Development
+npm run dev              # Start dev server on localhost:3000
+
+# Build
+npm run build            # Build Next.js (also runs prisma migrate deploy via postbuild)
+
+# Database
+npm run prismaDev        # Run Prisma migrations in development
+npm run prisma:migrate   # Deploy migrations (production)
+npm run prisma:generate  # Regenerate Prisma Client after schema changes
+npm run prismaStudio     # Open Prisma Studio UI
+
+# Linting
+npm run lint             # Run ESLint
+```
+
+No test suite is configured in this project.
+
+## Architecture Overview
+
+This is a **multi-tenant e-commerce platform** for sports teams to sell custom apparel. Each team has a unique catalog slug (e.g., `/catalog/cinco`), passcode-gated via cookies.
+
+**Stack**: Next.js 14 App Router · TypeScript · Tailwind CSS · Prisma 6 + PostgreSQL (Neon) · Square (payments) · Shippo (shipping) · Mailgun (email) · AWS S3 (images)
+
+### App Router Structure
+
+```
+app/
+├─ layout.tsx                  # Root layout wraps everything in LayoutWrapper
+├─ layout.client.tsx           # Client layout: ToastProvider → Header → ClientLayout
+├─ catalog/[slug]/             # Team catalog route, passcode-gated
+├─ cart/                       # Checkout flow (force-dynamic)
+├─ confirmation/               # Post-payment confirmation
+├─ admin/                      # Admin dashboard (no auth protection)
+└─ api/                        # All API routes (see below)
+```
+
+`ClientLayout` (in `layout.client.tsx`) composes the global provider tree:
+`StoreConfigProvider → CustomerDataProvider → CartProvider → page`
+
+### Context / State
+
+| Context | Purpose |
+|---|---|
+| `CartContext` | Cart state with localStorage persistence; handles add-Fit (+$5), XL (+$3), add-back pricing |
+| `StoreConfigContext` | Store branding, product catalog, player roster; 24h localStorage cache with version check |
+| `CustomerDataContext` | Customer info collected during checkout |
+| `ToastContext` | Toast notifications |
+
+### API Routes
+
+```
+/api/orders/              → CRUD for orders; POST creates customer + order atomically
+/api/orders/[id]/         → GET/PUT order; DELETE queues for background cleanup
+/api/square/create-payment-link/  → Generate Square checkout link (idempotency key required)
+/api/webhooks/square/     → Square payment completion webhook → triggers email
+/api/shippo/              → GET rates; /buy-rate purchases label; /save-rate persists selection
+/api/storeConfig/         → GET store config (branding, items, players)
+/api/customers/byStore/   → Fetch customers for a store
+/api/admin/               → Admin bulk operations
+/api/cron/finalize-deletes/ → Background cleanup job for queued order deletions
+```
+
+### Order Creation Flow
+
+```
+Cart → OrderForm (collect address) 
+→ POST /api/orders (create Customer + Order + OrderItems) 
+→ POST /api/square/create-payment-link 
+→ Mailgun confirmation emails (customer + merchant)
+→ Redirect to Square hosted checkout
+```
+
+Payment completion triggers the Square webhook which updates `PaymentStatus` on the order.
+
+### Database Schema Key Points
+
+- **Order** → has many **OrderItem**, one optional **ShippingLabel**, one optional **ShippingRateSelection**
+- Cascade deletes: deleting an Order removes related items, labels, and rate selections
+- `paymentLinkId` on Order is used as idempotency key for Square
+- `storeId` on Order/Customer enables multi-tenant filtering
+- Enums: `Categories`, `PaymentStatus` (PENDING/COMPLETED/FAILED), `OrderStatus` (ACTIVE/CANCEL_REQUESTED/CANCELED), `RefundStatus`
+
+### Multi-Store / Multi-Tenant
+
+- Each store lives at `/catalog/[slug]`
+- Access is gated by a passcode stored as a cookie (`isAuthenticated`)
+- Store config (branding, colors, logo, items, player roster) is loaded via `/api/storeConfig`
+- Orders and customers are scoped by `storeId`
+
+### Key Utilities
+
+- `utils/server.ts` — `withRetry()` for resilient external API calls
+- `utils/images.tsx` — `getS3ImageUrl()` for S3 image URLs
+- `utils/email.ts` — Mailgun email wrapper
+- `utils/numUtils.js` — numeric formatting
+
+### Configuration Notes
+
+- `next.config.mjs`: standalone output mode (for Vercel/Docker), S3 image domains whitelisted
+- Path alias `@/*` maps to project root (configured in `tsconfig.json`)
+- Square supports sandbox/production via env var toggle
+- `export const dynamic = "force-dynamic"` is used on pages that must not be cached (cart, auth-gated pages)

--- a/app/api/cron/finalize-deletes/route.ts
+++ b/app/api/cron/finalize-deletes/route.ts
@@ -2,9 +2,9 @@ import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { Shippo } from "shippo";
 
-const SHIPPO_TEST_API_KEY = process.env.SHIPPO_TEST_API_KEY || "";
+const SHIPPO_API_KEY = process.env.SHIPPO_API_KEY || "";
 const shippo = new Shippo({
-  apiKeyHeader: `ShippoToken ${SHIPPO_TEST_API_KEY}`,
+  apiKeyHeader: `ShippoToken ${SHIPPO_API_KEY}`,
   shippoApiVersion: "2018-02-08",
 });
 

--- a/app/api/orders/[orderId]/cancel-request/route.ts
+++ b/app/api/orders/[orderId]/cancel-request/route.ts
@@ -2,9 +2,9 @@ import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { Shippo } from "shippo";
 
-const SHIPPO_TEST_API_KEY = process.env.SHIPPO_TEST_API_KEY || "";
+const SHIPPO_API_KEY = process.env.SHIPPO_API_KEY || "";
 const shippo = new Shippo({
-  apiKeyHeader: `ShippoToken ${SHIPPO_TEST_API_KEY}`,
+  apiKeyHeader: `ShippoToken ${SHIPPO_API_KEY}`,
   shippoApiVersion: "2018-02-08",
 });
 

--- a/app/api/orders/catalogOrders/[catalogId]/route.ts
+++ b/app/api/orders/catalogOrders/[catalogId]/route.ts
@@ -4,9 +4,9 @@ import { Shippo } from "shippo";
 
 const prisma = new PrismaClient();
 
-const SHIPPO_TEST_API_KEY = process.env.SHIPPO_TEST_API_KEY || "";
+const SHIPPO_API_KEY = process.env.SHIPPO_API_KEY || "";
 const shippo = new Shippo({
-  apiKeyHeader: `ShippoToken ${SHIPPO_TEST_API_KEY}`,
+  apiKeyHeader: `ShippoToken ${SHIPPO_API_KEY}`,
   shippoApiVersion: "2018-02-08",
 });
 

--- a/app/api/orders/filterByCustomer/route.ts
+++ b/app/api/orders/filterByCustomer/route.ts
@@ -2,9 +2,9 @@ import { NextResponse } from "next/server";
 import prisma from "../../../../lib/prisma";
 import { Shippo } from "shippo";
 
-const SHIPPO_TEST_API_KEY = process.env.SHIPPO_TEST_API_KEY || "";
+const SHIPPO_API_KEY = process.env.SHIPPO_API_KEY || "";
 const shippo = new Shippo({
-  apiKeyHeader: `ShippoToken ${SHIPPO_TEST_API_KEY}`,
+  apiKeyHeader: `ShippoToken ${SHIPPO_API_KEY}`,
   shippoApiVersion: "2018-02-08",
 });
 

--- a/app/api/shippo/buy-rate/route.ts
+++ b/app/api/shippo/buy-rate/route.ts
@@ -2,9 +2,9 @@ import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { Shippo } from "shippo";
 
-const SHIPPO_TEST_API_KEY = process.env.SHIPPO_TEST_API_KEY || "";
+const SHIPPO_API_KEY = process.env.SHIPPO_API_KEY || "";
 const shippo = new Shippo({
-  apiKeyHeader: `ShippoToken ${SHIPPO_TEST_API_KEY}`,
+  apiKeyHeader: `ShippoToken ${SHIPPO_API_KEY}`,
   shippoApiVersion: "2018-02-08",
 });
 

--- a/app/api/shippo/label/buy/route.ts
+++ b/app/api/shippo/label/buy/route.ts
@@ -2,9 +2,9 @@ import { NextRequest, NextResponse } from "next/server";
 import { Shippo } from "shippo";
 import prisma from "@/lib/prisma"; // Adjust import based on your DB client
 
-const SHIPPO_TEST_API_KEY = process.env.SHIPPO_TEST_API_KEY || "";
+const SHIPPO_API_KEY = process.env.SHIPPO_API_KEY || "";
 const shippo = new Shippo({
-  apiKeyHeader: `ShippoToken ${SHIPPO_TEST_API_KEY}`,
+  apiKeyHeader: `ShippoToken ${SHIPPO_API_KEY}`,
   shippoApiVersion: "2018-02-08",
 });
 

--- a/app/api/shippo/label/route.ts
+++ b/app/api/shippo/label/route.ts
@@ -2,9 +2,9 @@ import { NextRequest, NextResponse } from "next/server";
 import { Shippo } from "shippo";
 import prisma from "@/lib/prisma"; // Adjust import based on your DB client
 
-const SHIPPO_TEST_API_KEY = process.env.SHIPPO_TEST_API_KEY || "";
+const SHIPPO_API_KEY = process.env.SHIPPO_API_KEY || "";
 const shippo = new Shippo({
-  apiKeyHeader: `ShippoToken ${SHIPPO_TEST_API_KEY}`,
+  apiKeyHeader: `ShippoToken ${SHIPPO_API_KEY}`,
   shippoApiVersion: "2018-02-08",
 });
 

--- a/app/api/shippo/route.ts
+++ b/app/api/shippo/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { Rate, Shippo } from "shippo";
 
-const SHIPPO_TEST_API_KEY = process.env.SHIPPO_TEST_API_KEY || "";
+const SHIPPO_API_KEY = process.env.SHIPPO_API_KEY || "";
 const shippo = new Shippo({
-  apiKeyHeader: `ShippoToken ${SHIPPO_TEST_API_KEY}`,
+  apiKeyHeader: `ShippoToken ${SHIPPO_API_KEY}`,
   shippoApiVersion: "2018-02-08",
 });
 


### PR DESCRIPTION
## Summary

- Full Shippo shipping integration (rate fetching, label purchase, tracking)
- New DB models: `ShippingLabel`, `ShippingRateSelection`
- New enums: `OrderStatus` (ACTIVE/CANCEL_REQUESTED/CANCELED), `RefundStatus`
- New `Order` fields: `status`, `labelPurchased`, `isPickup`, `canceledAt`, `deleteQueuedAt`
- All `SHIPPO_TEST_API_KEY` refs replaced with `SHIPPO_API_KEY` — set live key in Vercel Production env before merging
- 6 additive DB migrations — all new columns have safe defaults, no data loss

## New API Routes

- `POST /api/shippo` — fetch shipping rates for an address
- `POST /api/shippo/save-rate` — persist rate selection to DB
- `POST /api/shippo/buy-rate` — purchase label from saved rate
- `POST /api/shippo/label` — purchase label directly by rateId
- `GET /api/cron/finalize-deletes` — background job for refund/delete cleanup

## Pre-merge Checklist

- [ ] Add `SHIPPO_API_KEY` (live key) to Vercel **Production** environment
- [ ] Add `SHIPPO_API_KEY` (test key) to Vercel **Preview/Development** environments
- [ ] Confirm Neon production DB will receive migrations via `postbuild` → `prisma migrate deploy`

## Post-deploy Smoke Test

- [ ] Catalog page loads without errors
- [ ] Admin dashboard displays orders with `status = ACTIVE`
- [ ] `/api/shippo` returns rates for a valid address

🤖 Generated with [Claude Code](https://claude.com/claude-code)