### PR TITLE
Texas Twelve store setup; fix Dri-Fit upcharge not applying to plain …

### DIFF
--- a/app/api/orders/[orderId]/route.ts
+++ b/app/api/orders/[orderId]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import prisma from "../../../../lib/prisma";
 
-const DRIFIT_MATERIAL = "Dri-Fit";
+const DRIFIT_MATERIAL = "Dri-Fit (+ $5)";
 const DRIFIT_SURCHARGE = 5;
 const OVERSIZE_SURCHARGE = 3;
 const OVERSIZE_SIZES = ["2XL", "3XL", "4XL"];
@@ -10,9 +10,9 @@ const DEFAULT_BACKOPTION_PRICE = 2;
 // GET request handler for fetching an order with customer and items
 export async function GET(
   req: Request,
-  { params }: { params: { orderId: string } }
+  { params }: { params: Promise<{ orderId: string }> }
 ) {
-  const { orderId } = params;
+  const { orderId } = await params;
 
   try {
     const order = await prisma.order.findUnique({
@@ -53,9 +53,9 @@ export async function GET(
 // DELETE request handler for deleting an order
 export async function DELETE(
   req: Request,
-  { params }: { params: { orderId: string } }
+  { params }: { params: Promise<{ orderId: string }> }
 ) {
-  const { orderId } = params;
+  const { orderId } = await params;
   const url = new URL(req.url);
   const storeId = url.searchParams.get("storeId");
 

--- a/app/api/square/create-payment-link/route.ts
+++ b/app/api/square/create-payment-link/route.ts
@@ -199,7 +199,7 @@ export async function POST(req: NextRequest) {
         orderPrice: item.unitPrice * item.quantity,
         color: item.color,
         size: item.size,
-        material: item.material === "Dri-Fit" ? "Dri-Fit (+ $5)" : item.material,
+        material: item.material,
         isAddBack: item.isAddBack,
         notes: item.notes,
         playerName: item.playerName,

--- a/app/catalog/catalogConfigs.tsx
+++ b/app/catalog/catalogConfigs.tsx
@@ -12,6 +12,7 @@ import { cinco } from "./teams/cinco";
 import { hustlelctx } from "./teams/hustlelctx";
 import { hustleguzman } from "./teams/hustleguzman";
 import { diamondWarriors } from "./teams/diamondwarriors";
+import { txTwelve } from "./teams/txtwelve";
 
 export const stores: Record<string, StoreConfig> = {
   store1: {
@@ -64,4 +65,5 @@ export const stores: Record<string, StoreConfig> = {
   hustlelctx,
   hustleguzman,
   diamondwarriors: diamondWarriors,
+  txtwelve: txTwelve,
 };

--- a/app/catalog/teams/txtwelve.tsx
+++ b/app/catalog/teams/txtwelve.tsx
@@ -1,0 +1,60 @@
+import { Categories } from "../../../_types";
+export const DRIFIT = "Dri-Fit (+ $5)";
+const youthSizes = ["YS", "YM", "YL", "YXL"];
+const sizes = ["S", "M", "L", "XL", "2XL", "3XL", "4XL"];
+const allSizes = [...youthSizes, ...sizes];
+export const DEFAULT_PLAYER_NUMBER = "n/a";
+
+export const txTwelve = {
+  id: 9,
+  version: 1,
+  name: "Texas Twelve 10U Maroon Katy",
+  branding: {
+    logo: "",
+    primaryColor: "#ffffff",
+    secondaryColor: "#7B1728",
+  },
+  passcode: "txtwelve",
+  localPickupOnly: true,
+  players: [
+    { name: "Kathryn Schmidt-Pena", number: "1" },
+    { name: "Emma Schoeneberg", number: "5" },
+    { name: "Faith Piper", number: "6" },
+    { name: "Ariel Segovia", number: "7" },
+    { name: "Elle Wallace", number: "8" },
+    { name: "Gianna Campise", number: "9" },
+    { name: "Lindsey Deleon", number: "10" },
+    { name: "Sydni Vandeventer", number: "12" },
+    { name: "Audrey Ramirez", number: "13" },
+    { name: "Madison Rosario", number: "14" },
+    { name: "Savannah Henningson", number: "15" },
+    { name: "Sophie Hassall", number: "16" },
+    { name: "Gaby Perez", number: "20" },
+    { name: "Kaylee Barnett", number: "25" },
+    { name: "Ossie Coulte", number: "32" },
+    { name: "Coach", number: "n/a" },
+  ],
+  items: [
+    {
+      id: 1,
+      title: "Texas Twelve Fan Shirt",
+      isCustomizable: false,
+      showBackSelection: false,
+      isBackRequired: false,
+      category: Categories.TSHIRTS,
+      price: 25.0,
+      image: "txtwelve/txtwelve-black-frontBack.png",
+      images: [
+        {
+          id: 0,
+          imageUrl: "txtwelve/txtwelve-black-frontBack.png",
+          color: "Black",
+        },
+      ],
+      sizes: allSizes,
+      colors: ["Black"],
+      material: ["Dri-Fit"],
+      orders: [],
+    },
+  ],
+};


### PR DESCRIPTION
…material string

- Add txTwelve store config and wire into catalogConfigs
- Fix orders/[orderId] route: DRIFIT_MATERIAL was "Dri-Fit" causing $5 surcharge on all Dri-Fit items regardless of whether upcharge was intended — changed to "Dri-Fit (+ $5)" to match the signal string
- Remove stale "Dri-Fit" → "Dri-Fit (+ $5)" label remap in create-payment-link email data
- Update params to async pattern in orderId route handlers