### PR TITLE
Fix admin crash on stores with orders — null labelPurchased causes Pr…

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -74,9 +74,17 @@ const AdminDashboard = () => {
   };
   const fetchOrders = async (catalogId: number) => {
     try {
-      const response = await fetch(`/api/orders/catalogOrders/${catalogId}`); // API to fetch orders for the catalog
+      const response = await fetch(`/api/orders/catalogOrders/${catalogId}`);
+      if (!response.ok) {
+        console.error("Failed to fetch orders:", response.status);
+        return;
+      }
       const data = await response.json();
-      setOrders(data);
+      if (Array.isArray(data)) {
+        setOrders(data);
+      } else {
+        console.error("Unexpected orders response:", data);
+      }
     } catch (error) {
       console.error("Error fetching orders:", error);
     }

--- a/prisma/migrations/20260528000000_fix_label_purchased_nulls/migration.sql
+++ b/prisma/migrations/20260528000000_fix_label_purchased_nulls/migration.sql
@@ -1,0 +1,3 @@
+-- Fix null labelPurchased values on orders that predate the NOT NULL constraint.
+-- Prisma 6 throws P2032 when it finds null for a non-nullable Boolean field.
+UPDATE "Order" SET "labelPurchased" = false WHERE "labelPurchased" IS NULL;


### PR DESCRIPTION
…isma P2032

Some Order rows in production have labelPurchased = NULL despite the NOT NULL schema constraint. Prisma 6 throws P2032 when deserializing those rows, causing the GET /api/orders/catalogOrders/[id] route to 500 for stores with real orders (hustle id:3, renegades id:2). The admin page then called .map() on the error object instead of an array, crashing the page.

- Add migration to backfill null labelPurchased → false
- Guard fetchOrders against non-ok responses and non-array payloads