### PR TITLE
Clear auth cookie when store is closed

### DIFF
--- a/app/layout.client.tsx
+++ b/app/layout.client.tsx
@@ -3,6 +3,7 @@
 
 import { ReactNode, useEffect, useState } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
+import Cookies from "js-cookie";
 import { StoreConfigProvider } from "../context/StoreConfigContext";
 import { CartProvider } from "../context/CartContext";
 import { CustomerDataProvider } from "../context/CustomerDataContext";
@@ -58,6 +59,9 @@ export function ClientLayout({ children }: { children: ReactNode }) {
           (latestConfig && latestConfig.version !== parsedConfig.version) ||
           (latestConfig && latestConfig.id !== parsedConfig.id)
         ) {
+          if (latestConfig.passcode !== parsedConfig.passcode) {
+            Cookies.remove("isAuthenticated");
+          }
           setStoreConfig(latestConfig);
           localStorage.setItem("storeConfig", JSON.stringify(latestConfig)); // Update localStorage with the new config
         } else {


### PR DESCRIPTION
## Summary

- When a store is closed (version bumped + passcode changed to `{original}-closed`), previously-authenticated users were still passing the passcode gate because the `isAuthenticated` cookie persisted
- Added a passcode comparison inside the version-mismatch block in `layout.client.tsx` — if the passcode changed, the cookie is removed before the new config is stored
- Version bumps from product additions (passcode unchanged) are unaffected

## Test plan

- [ ] Authenticate on an open store, confirm `isAuthenticated=true` cookie is set and catalog loads
- [ ] Bump the store's `version` and append `-closed` to its `passcode`, reload — passcode gate should appear
- [ ] Confirm entering the old passcode fails; entering nothing is also blocked
- [ ] Restore the config, re-auth with the correct passcode — confirm normal flow works
- [ ] Bump version only (no passcode change) — confirm the cookie is NOT cleared and catalog still loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)