### PR TITLE
Reopen reign store

### DIFF
--- a/app/catalog/teams/reign.tsx
+++ b/app/catalog/teams/reign.tsx
@@ -9,7 +9,7 @@ export const DEFAULT_PLAYER_NUMBER = "n/a";
 export const coach = { name: "Coach", number: DEFAULT_PLAYER_NUMBER };
 export const reign = {
   id: 5,
-  version: 26,
+  version: 27,
   name: "REIGN",
   branding: {
     logo: "",
@@ -31,7 +31,7 @@ export const reign = {
     { name: "SavannahBesselman", number: "15" },
     { name: "Coach", number: "n/a" },
   ],
-  passcode: "reign-closed",
+  passcode: "reign",
   items: [
     {
       id: 76,


### PR DESCRIPTION
## Summary
- Restore passcode from `reign-closed` back to `reign`
- Bump config version 26 → 27 to bust client-side localStorage cache

## Test plan
- [ ] Confirm `/catalog/reign` accepts passcode `reign` after deploy
- [ ] Confirm existing clients with cached config pick up v27 and see the store as open